### PR TITLE
Bump OpenTAP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ LABEL com.github.actions.icon="git-pull-request"
 LABEL com.github.actions.color="orange"
 
 # Relayer the .NET SDK, anew with the build output  
-FROM opentapio/opentap:beta-bionic-slim
+FROM opentapio/opentap:beta-slim
 COPY --from=build-env /out/Newtonsoft.Json.dll /opt/tap
 COPY --from=build-env /out/Octokit.dll /opt/tap
 COPY --from=build-env /out/Octokit.GraphQL.dll /opt/tap

--- a/pr-version-comment.csproj
+++ b/pr-version-comment.csproj
@@ -6,7 +6,7 @@
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <CopyOpenTapPayloadFiles>true</CopyOpenTapPayloadFiles>
-    <OpenTapVersion>9.17.0-beta.11</OpenTapVersion>
+    <OpenTapVersion>9.23.2-rc.1</OpenTapVersion>
     <RootNamespace>PRVersionComment</RootNamespace>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
OpenTAP gitversion behavior has changed in 9.23.2

We need to create a v2 of this action with the new behavior